### PR TITLE
Replace RawGit links with jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are several `font-family` you can choose from (all Powerline-enabled):
   * `Monofur` - [Monofur for Powerline](https://github.com/powerline/fonts/tree/master/Monofur)
     
 
-See [preview.html](https://rawgit.com/wernight/powerline-web-fonts/master/preview.html) and [Slant](http://www.slant.co/topics/67/~programming-fonts) if you don't know which to choose.
+See [Slant](http://www.slant.co/topics/67/~programming-fonts) if you don't know which to choose.
 
 ## Usage example
 
@@ -34,7 +34,7 @@ See [preview.html](https://rawgit.com/wernight/powerline-web-fonts/master/previe
   - Launch *Secure Shell* and click on **Options**
     (or go to `chrome-extension://pnhechapfaindjhompbnflcldabbghjo/html/nassh_preferences_editor.html`):
       - Set **font-family**: `"Source Code Pro", monospace`
-      - Set **user-css**: `https://cdn.rawgit.com/wernight/powerline-web-fonts/ba4426cb0c0b05eb6cb342c7719776a41e1f2114/PowerlineFonts.css`
+      - Set **user-css**: `https://cdn.jsdelivr.net/gh/wernight/powerline-web-fonts@ba4426cb0c0b05eb6cb342c7719776a41e1f2114/PowerlineFonts.css`
 
 ### Usage example for [Crosh Window](https://chrome.google.com/webstore/detail/crosh-window/nhbmpbdladcchdhkemlojfjdknjadhmh)
 
@@ -42,14 +42,12 @@ See [preview.html](https://rawgit.com/wernight/powerline-web-fonts/master/previe
 
 ```js
 term_.prefs_.set('font-family', '"Source Code Pro", monospace');
-term_.prefs_.set('user-css', 'https://cdn.rawgit.com/wernight/powerline-web-fonts/ba4426cb0c0b05eb6cb342c7719776a41e1f2114/PowerlineFonts.css');
+term_.prefs_.set('user-css', 'https://cdn.jsdelivr.net/gh/wernight/powerline-web-fonts@ba4426cb0c0b05eb6cb342c7719776a41e1f2114/PowerlineFonts.css');
 ```
 
 If you have [Crouton](https://github.com/dnschneid/crouton) installed on a developer mode Chromebook,
 or if you're on pretty much any other OS, you can install those fonts locally or copy them locally
 and it'll work with little to no effort.
-
-Note that the RawGit links require a specific commit SHA-1 because files are cached permanently. Please update your projects to use the `CDN` links, as [overusage of the development URLs (those without `cdn.`), could result in this repo being blacklisted from RawGit](https://github.com/rgrove/rawgit/wiki/Frequently-Asked-Questions).
 
 ## Suggesting a new font
 


### PR DESCRIPTION
Close #16 by updating RawGit links in `README.md` to use jsDelivr. 

jsDelivr won't serve the `text/html` content type, so a link to `preview.html` would be broken and has been removed. However the preview file itself isn't deleted in this commit.